### PR TITLE
Fixed simple_led.ino

### DIFF
--- a/examples/simple_led/simple_led.ino
+++ b/examples/simple_led/simple_led.ino
@@ -14,9 +14,6 @@
 
 #include <Arduino.h>
 #include <ESP8266WiFi.h>
-#include <homekit/types.h>
-#include <homekit/homekit.h>
-#include <homekit/characteristics.h>
 
 #include <arduino_homekit_server.h>
 #include "ButtonDebounce.h"


### PR DESCRIPTION
Some libraries in the simple_led.ino file where not required. However, they also prevented the example from compile because the Arduino IDE will refuse to load any library files located in a subdirectory of the library.