### PR TITLE
add yield() to prevent Soft WDT Resets with ARDUINO_HOMEKIT_LOWROM

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -432,6 +432,13 @@ int crypto_ed25519_sign(
         return -2;
     }
 
+#if defined(ARDUINO_HOMEKIT_LOWROM)
+    /*  ESP8266 Soft WDT resets with 512k ROMs.
+        Add yield() to perform other tasks and feed WDT.
+    */
+    yield();
+#endif
+
     word32 len = *signature_size;
 
     int r = wc_ed25519_sign_msg(
@@ -452,6 +459,12 @@ int crypto_ed25519_verify(
 #if defined(ARDUINO_HOMEKIT_SKIP_ED25519_VERIFY)
 	return 0;
 #else
+#if defined(ARDUINO_HOMEKIT_LOWROM)
+    /*  ESP8266 Soft WDT resets with 512k ROMs.
+        Add yield() to perform other tasks and feed WDT.
+    */
+    yield();
+#endif
     int verified;
     int r = wc_ed25519_verify_msg(
         signature, signature_size,


### PR DESCRIPTION
I have a single ESP8266 512k module that had to be configured with ARDUINO_HOMEKIT_LOWROM option.  When enabling this, I've found that the ed25519 functions (_sign in particular) usually triggered the Soft WatchDog Timer and reset the module.  Adding in the yield statements resolved this issue.